### PR TITLE
fix: Zeilenumbrüche im Release-Body korrekt darstellen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,13 +177,21 @@ jobs:
           maxIssues: 50
           excludeLabels: "duplicate,question,invalid,wontfix"
 
+      # SCHRITT 8b: Changelog in Datei schreiben und URL-Kodierung (%0a) dekodieren
+      # GitHub Actions kodiert Zeilenumbrüche in Step-Outputs als %0a/%0d
+      - name: "Write changelog to file"
+        env:
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+        run: |
+          printf '%s' "$CHANGELOG" | sed 's/%0[aA]/\n/g; s/%0[dD]//g' > release_notes.md
+
       # SCHRITT 9a: Stabiles Release erstellen (für normale Versionen)
       # Wird nur ausgeführt wenn Version NICHT "beta" enthält
       - name: Create Stable release
         uses: softprops/action-gh-release@v2
         with:
           prerelease: false  # Markiert als stabile Version
-          body: "${{ steps.changelog.outputs.changelog }}"
+          body_path: release_notes.md
           name: "Version ${{ env.COMPONENT_VERSION }}"
           tag_name: "v${{ env.COMPONENT_VERSION }}"
           target_commitish: "${{ env.CURRENT_SHA }}"
@@ -195,7 +203,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           prerelease: true  # Markiert als Vorabversion
-          body: "${{ steps.changelog.outputs.changelog }}"
+          body_path: release_notes.md
           name: "Version ${{ env.COMPONENT_VERSION }}"
           tag_name: "v${{ env.COMPONENT_VERSION }}"
           target_commitish: "${{ env.CURRENT_SHA }}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flower-card",
-  "version": "2026.6.2-beta.1",
+  "version": "2026.6.2",
   "description": "Custom flower card for https://github.com/Olen/homeassistant-plant",
   "keywords": [
     "home-assistant",


### PR DESCRIPTION
GitHub Actions kodiert Newlines in Step-Outputs als %0a. Statt den
Changelog direkt via `body:` einzufügen, wird er jetzt in eine Datei
geschrieben (mit sed-Dekodierung von %0a/%0d) und über `body_path:`
referenziert.

https://claude.ai/code/session_01MAUzr5AYeZ3jW7jTqq8Cwd